### PR TITLE
Replaced recursive functions with while loops to avoid hitting recursion limits

### DIFF
--- a/R/CompProbDown.R
+++ b/R/CompProbDown.R
@@ -1,10 +1,15 @@
-CompProbDown <-
-function(nAA,nBB,EnAB,prob,vec=NULL) {
-  pr <-  prob*EnAB*(EnAB-1)/(4*(nAA+1)*(nBB+1))
-  nvec <- c(vec,pr)
-  if(EnAB > 3) {
-     nvec <- CompProbDown(nAA+1,nBB+1,EnAB-2,pr,nvec)
+CompProbDown <- function(nAA,nBB,EnAB,prob,vec=NULL) 
+{
+  prob <-  prob*EnAB*(EnAB-1)/(4*(nAA+1)*(nBB+1))
+  nvec <- c(vec, prob)
+  
+  while(EnAB > 3) {
+    nAA <- nAA + 1
+    nBB <- nBB + 1
+    EnAB <- EnAB - 2
+    prob <-  prob*EnAB*(EnAB-1)/(4*(nAA+1)*(nBB+1))
+    nvec <- c(nvec ,prob)
   }
+  
   return(nvec)
 }
-

--- a/R/CompProbUp.R
+++ b/R/CompProbUp.R
@@ -1,10 +1,13 @@
-CompProbUp <-
-function(nAA,nBB,EnAB,prob,MaxHet,vec=NULL) {
-  pr <-  prob*4*nAA*nBB/((EnAB+2)*(EnAB+1))
-  nvec <- c(vec,pr)
-  if(EnAB < MaxHet-2) {
-     nvec <- CompProbUp(nAA-1,nBB-1,EnAB+2,pr,MaxHet,nvec)
+CompProbUp <- function(nAA,nBB,EnAB,prob,MaxHet,vec=NULL) {
+  prob <-  prob*4*nAA*nBB/((EnAB+2)*(EnAB+1))
+  nvec <- c(vec, prob)
+  
+  while (EnAB < MaxHet-2) {
+    nAA <- nAA - 1
+    nBB <- nBB - 1
+    EnAB <- EnAB + 2
+    prob <-  prob*4*nAA*nBB/((EnAB+2)*(EnAB+1))
+    nvec <- c(nvec ,prob)
   }
   return(nvec)
 }
-


### PR DESCRIPTION
Hi, I've rewritten the probability calculation functions as while loops. The current implementation was hitting stack limits (due to self-recursion) when the no. of genotypes was particular large.

e.g.
`HWExact(c(AA = 88447, AB = 30802, BB = 3563), x.linked = F)`

On Linux, the error being displayed was
`Error: node stack overflow`

On OS X
`C stack usage 7970184 is too close to the limit`

Hopefully this alleviates that. I've done regression testing to ensure that the rewritten functions behave exactly as per existing ones.
